### PR TITLE
j7elte: wpa_supplicant_overlay: Enable p2p

### DIFF
--- a/configs/wifi/wpa_supplicant_overlay.conf
+++ b/configs/wifi/wpa_supplicant_overlay.conf
@@ -1,2 +1,1 @@
-p2p_disabled=1
 tdls_external_control=1


### PR DESCRIPTION
WiFi direct has been fixed by https://github.com/LineageOS/android_device_samsung_universal7580-common/commit/469e9ed04a0565e63616c1c491b44eb3b56ed5f0

Change-Id: I6d81d403a7effab01c29cb06af63055f029e786d